### PR TITLE
Make forecast initial example

### DIFF
--- a/frontend/components/columns/center/center.js
+++ b/frontend/components/columns/center/center.js
@@ -28,6 +28,12 @@ document.addEventListener("DOMContentLoaded", () => {
           )}</p>
           `;
           break;
+        case "exampleHTML":
+          forecastContainer.innerHTML = localStorage.getItem("exampleHTML");
+          break;
+        case "exampleJSON":
+          forecastContainer.innerHTML = localStorage.getItem("exampleJSON");
+          break;
         default:
       }
     }

--- a/frontend/components/home/forecast_container/_forecast_container.html.erb
+++ b/frontend/components/home/forecast_container/_forecast_container.html.erb
@@ -1,94 +1,51 @@
 <section id="forecast-container" class="forecast-cont">
-  <p class="json">{<br>
-      "data": [<br>
-          {<br>
-              "id": "1",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1,<br>
-                  "spot_id": 1,<br>
-                  "location": "Newquay - Fistral North",<br>
-                  "latitude": 50.4184,<br>
-                  "longitude": -5.0997<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "905",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 905,<br>
-                  "spot_id": 967,<br>
-                  "location": "Newquay - Great Western",<br>
-                  "latitude": 50.4162,<br>
-                  "longitude": -5.0781<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "1211",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1211,<br>
-                  "spot_id": 1336,<br>
-                  "location": "Newquay - Tolcarne Wedge",<br>
-                  "latitude": 50.4176,<br>
-                  "longitude": -5.0749<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "1212",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1212,<br>
-                  "spot_id": 1337,<br>
-                  "location": "Newquay - Porth",<br>
-                  "latitude": 50.4256,<br>
-                  "longitude": -5.0659<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "1223",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1223,<br>
-                  "spot_id": 1360,<br>
-                  "location": "Newquay-  Little Fistral",<br>
-                  "latitude": 50.4229,<br>
-                  "longitude": -5.1<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "1224",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1224,<br>
-                  "spot_id": 1361,<br>
-                  "location": "Newquay - Fistral South ",<br>
-                  "latitude": 50.4141,<br>
-                  "longitude": -5.1025<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "1225",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 1225,<br>
-                  "spot_id": 1362,<br>
-                  "location": "Newquay - Cribbar",<br>
-                  "latitude": 50.4254,<br>
-                  "longitude": -5.1026<br>
-              }<br>
-          },<br>
-          {<br>
-              "id": "5019",<br>
-              "type": "spot",<br>
-              "attributes": {<br>
-                  "id": 5019,<br>
-                  "spot_id": 6025,<br>
-                  "location": "Newquay - Towan",<br>
-                  "latitude": 50.4175,<br>
-                  "longitude": -5.0841<br>
-              }<br>
-          }<br>
-      ]<br>
-  } </p>
+  <div class="request-format-bttns">
+    <button id="exampleHTML" class="format-bttn">Pretty</button>
+    <button id="exampleJSON" class="format-bttn">JSON</button>
+  </div>
+  <h2 class="location-name"> Newquay - Fistral North </h2>
+  <table class="forecast-table">
+    <tbody><tr>
+      <td>Faded Rating</td>
+      <td>4</td>
+    </tr>
+    <tr>
+      <td>Solid Rating</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Issued</td>
+      <td>Fri Jan  3 06:00:00 2020</td>
+    </tr>
+    <tr>
+      <td>Minimum Breaking Height</td>
+      <td>7ft</td>
+    </tr>
+    <tr>
+      <td>Maximum Breaking Height</td>
+      <td>10ft</td>
+    </tr>
+    <tr>
+      <td>Wind Speed</td>
+      <td>17mph</td>
+    </tr>
+    <tr>
+      <td>Wind Gusts</td>
+      <td>20mph</td>
+    </tr>
+    <tr>
+      <td>Temperature</td>
+      <td>48f</td>
+    </tr>
+  </tbody></table>
+  <div id="carousel-cont" class="carousel-container">
+    <div class="carousel">
+      <img class="carousel-image initial" src="https://charts-s3.msw.ms/archive/wave/750/1-1578063600-1.gif">
+      <img class="carousel-image" src="https://charts-s3.msw.ms/archive/wave/750/1-1578063600-2.gif">
+      <img class="carousel-image" src="https://charts-s3.msw.ms/archive/gfs/750/1-1578063600-4.gif">
+      <img class="carousel-image" src="https://charts-s3.msw.ms/archive/gfs/750/1-1578063600-3.gif">
+      <div id="next-bttn" class="carousel-next-button"></div>
+      <div id="prev-bttn" class="carousel-prev-button"></div>
+    </div>
+  </div>
 </section>

--- a/frontend/components/home/forecast_container/forecast_container.pcss
+++ b/frontend/components/home/forecast_container/forecast_container.pcss
@@ -6,7 +6,7 @@
   box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.2), -3px -3px 5px rgba(0, 0, 0, 0.2);
   margin-top: 20px;
   border-radius: 4px;
-  max-height: 500px;
+  max-height: 460px;
   overflow: scroll;
 }
 

--- a/frontend/components/home/routes/_routes.html.erb
+++ b/frontend/components/home/routes/_routes.html.erb
@@ -1,7 +1,7 @@
 <div id="route-cont" class="routes-section">
   <h2 class="base-url"><span class="base-label">Base Url:</span> https://surf-forecast-api.herokuapp.com</h2>
   <h2 class="routes-title">Get Routes</h2>
-  <p id="search-locations" class="route selected">/api/v1/search/locations?query=string</p>
-  <p id="surf-forecast" class="route">/api/v1/:spot_id/surf</p>
+  <p id="search-locations" class="route">/api/v1/search/locations?query=string</p>
+  <p id="surf-forecast" class="route selected">/api/v1/:spot_id/surf</p>
   <p id="all-locations" class="route">/api/v1/locations</p>
 </div>

--- a/frontend/components/home/routes/response_json.js
+++ b/frontend/components/home/routes/response_json.js
@@ -155,40 +155,43 @@ export default function() {
   }
 
   function surfForecast() {
-    return `<p class='json'>{<br>
-          "data": {<br>
-              "id": "1",<br>
-              "type": "forecast",<br>
-              "attributes": {<br>
-                  "faded_rating": 0,<br>
-                  "solid_rating": 3,<br>
-                  "issue_timestamp": "Wed Jan  1 06:00:00 2020",<br>
-                  "local_timestamp": "Wed Jan  1 21:00:00 2020",<br>
-                  "min_break_height": 2,<br>
-                  "max_break_height": 4,<br>
-                  "wave_unit": "ft",<br>
-                  "wind_direction": "S",<br>
-                  "wind_speed": 9,<br>
-                  "wind_gusts": 12,<br>
-                  "wind_unit": "mph",<br>
-                  "temperature": 47,<br>
-                  "temperature_unit": "f",<br>
-                  "charts": {<br>
-                      "swell": "https://charts-s3.msw.ms/archive/wave/750/1-1577912400-1.gif",<br>
-                      "period": "https://charts-s3.msw.ms/archive/wave/750/1-1577912400-2.gif",<br>
-                      "wind": "https://charts-s3.msw.ms/archive/gfs/750/1-1577912400-4.gif",<br>
-                      "pressure": "https://charts-s3.msw.ms/archive/gfs/750/1-1577912400-3.gif"<br>
-                  },<br>
-                  "location": {<br>
-                      "id": 1,<br>
-                      "spot_id": 1,<br>
-                      "location": "Newquay - Fistral North",<br>
-                      "latitude": 50.4184,<br>
-                      "longitude": -5.0997<br>
-                  }<br>
-              }<br>
-          }<br>
-      }</p>`;
+    return `
+      <div class="request-format-bttns">
+        <button id="exampleHTML" class="format-bttn">Pretty</button>
+        <button id="exampleJSON" class="format-bttn">JSON</button>
+      </div>
+      <p class='json'>{<br>
+         "id" : "1",<br>
+         "type" : "forecast",<br>
+         "attributes" : {<br>
+         "faded_rating" : 4,<br>
+         "solid_rating" : 1,<br>
+         "issue_timestamp" : "Fri Jan 3 06 : 00 : 00 2020",<br>
+         "local_timestamp" : "Fri Jan 3 15 : 00 : 00 2020",<br>
+         "min_break_height" : 7,<br>
+         "max_break_height" : 10,<br>
+         "wave_unit" : "ft",<br>
+         "wind_direction" : "NNW",<br>
+         "wind_speed" : 17,<br>
+         "wind_gusts" : 20,<br>
+         "wind_unit" : "mph",<br>
+         "temperature" : 48,<br>
+         "temperature_unit" : "f",<br>
+         "charts" : {<br>
+         "swell" : "https : //charts-s3.msw.ms/archive/wave/750/1-1578063600-1.gif",<br>
+         "period" : "https : //charts-s3.msw.ms/archive/wave/750/1-1578063600-2.gif",<br>
+         "wind" : "https : //charts-s3.msw.ms/archive/gfs/750/1-1578063600-4.gif",<br>
+         "pressure" : "https : //charts-s3.msw.ms/archive/gfs/750/1-1578063600-3.gif"<br>
+       },<br>
+         "location" : {<br>
+         "id" : 1,<br>
+         "spot_id" : 1,<br>
+         "location" : "Newquay - Fistral North",<br>
+         "latitude" : 50.4184,<br>
+         "longitude" : -5.0997<br>
+       }<br>
+     }<br>
+         }</p>`;
   }
 
   return {

--- a/frontend/components/home/routes/routes.js
+++ b/frontend/components/home/routes/routes.js
@@ -5,6 +5,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const routeCont = document.getElementById("route-cont");
   const routes = document.querySelectorAll(".route");
   const forecastCont = document.getElementById("forecast-container");
+
+  localStorage.setItem("exampleJSON", responseJson().surfForecast);
+  localStorage.setItem("exampleHTML", forecastCont.innerHTML);
   function insertExampleJson(event) {
     switch (event.target.id) {
       case "search-locations":
@@ -14,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
         forecastCont.innerHTML = responseJson().allLocations;
         break;
       case "surf-forecast":
-        forecastCont.innerHTML = responseJson().surfForecast;
+        forecastCont.innerHTML = localStorage.getItem("exampleJSON");
         break;
       default:
     }


### PR DESCRIPTION
This pull request:
* Improves the appearance of the page by using example html to start with instead of JSON
* Makes it clear that the forecast container holds HTML forecasts as well
* Allows the example JSON to be switched to and from HTML